### PR TITLE
TOPのヘッダー周り修正

### DIFF
--- a/assets/gulp/browserSync.js
+++ b/assets/gulp/browserSync.js
@@ -73,9 +73,8 @@ gulp.task("server",()=> {
             middleware: [pugMiddleWare],
             baseDir:"public",
             index: "index.html",
-            open: false
-
-        }
+        },
+        open: "external",F
     })
     return gulp.watch([
         `${dest}/**/*`,

--- a/assets/scss/project/11.2.header.scss
+++ b/assets/scss/project/11.2.header.scss
@@ -24,12 +24,18 @@ Styleguide 11.2
   flex-wrap: wrap;
   justify-content: space-between;
   & &__title{
-    width: 75%;
+    //width: 75%;
+    float: none;
+    @include media_desktop() {
+      float: left;
+    }
   }
   & &__cart{
     display: none;
+    float:none;
     @include media_desktop(){
       display: block;
+      float:right;
       @include reset_link;
     }
   }
@@ -325,14 +331,14 @@ Styleguide 11.2.4
     display: inline-block;
     font-weight: bold;
     @include reset_link;
-    padding: 16px;
-    height: 55px;
+    &:hover {
+      background: #fafafa;
+    }
     a {
       display: inline-block;
       margin-top: 0;
-      &:hover {
-        background: #fafafa;
-      }
+      padding: 16px;
+      height: 55px;
     }
     &:hover > .ec-itemNavAccordion {
       overflow: visible;

--- a/assets/scss/project/11.2.header.scss
+++ b/assets/scss/project/11.2.header.scss
@@ -1,5 +1,6 @@
 @import "../mixins/media";
 @import "../mixins/projects";
+@import "../mixins/clearfix";
 /*
 ヘッダー
 
@@ -17,6 +18,12 @@ Styleguide 11.2
 .ec-headerRole{
   @include container;
   padding-top: 15px;
+  &:after {
+    display: none;
+  }
+  @include media_desktop {
+    @include clearfix;
+  }
   &::before{
     display: none;
   }
@@ -236,7 +243,7 @@ Styleguide 11.2.3
   text-align: right;
   & &__item{
     display: inline-block;
-    width: 40%;
+    width: 30%;
     text-align: center;
   }
   & &__item:nth-of-type(2){

--- a/assets/scss/project/11.4.spmenu.scss
+++ b/assets/scss/project/11.4.spmenu.scss
@@ -15,20 +15,23 @@ p hoge
 Styleguide 11.4
 */
 .ec-drawerRole{
-  display: none;
+  display: block;
   background: #F6F6F6;
   position: fixed;
   top:0;
   width: 260px;
   height:100vh;
   right:0;
+  z-index: -1;
+  transition: z-index 0ms 1ms;
   @include media_desktop(){
     display: none;
   }
 }
 
 .ec-drawerRole.is_active{
-  display: block;
+  z-index: 1;
+  transition: z-index 0ms 300ms;
   @include media_desktop(){
     display: none;
   }
@@ -75,11 +78,16 @@ Styleguide 11.4.1
     .ec-itemNav__item{
       display: block;
       text-align: left;
-      padding:0 10px;
-      height: 50px;
       border-bottom: 1px solid #e8e8e8;
       line-height: 50px;
       font-weight: bold;
+      a {
+        padding:0 10px;
+        height: 50px;
+      }
+    }
+    .ec-itemNavAccordion {
+      display: none;
     }
   }
 }

--- a/assets/scss/project/11.6.layout.scss
+++ b/assets/scss/project/11.6.layout.scss
@@ -16,6 +16,8 @@ Styleguide 11.6
 */
 .ec-layoutRole{
   width: 100%;
+  transition: transform 0.3s;
+  background: #fff;
   & &__contentTop {
     padding: 0;
   }
@@ -40,6 +42,8 @@ Styleguide 11.6
 
 .ec-layoutRole.is_active{
   transform: translateX(-260px);
+  transition: transform 0.3s;
+  z-index: 10;
   @include media_desktop(){
     transform: translateX(0px);
   }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3,6 +3,7 @@
 body {
   font-family: Roboto, "游ゴシック", YuGothic, "Yu Gothic", "ヒラギノ角ゴ ProN W3", "Hiragino Kaku Gothic ProN", Arial, "メイリオ", Meiryo, sans-serif;
   color:#525263;
+  transition: z-index 0ms 5.28455ms;
 }
 @import "component/1.1.heading";
 @import "component/1.2.typo";


### PR DESCRIPTION
browserSyncにopen:externalの設定追加
【moc】TOP：画面幅が1000px以下になるとTOPのカートが段落ちするのを修正 #2
【moc】TOP：SP 版の Slide Navi transition対応 #2