### PR TITLE
【moc】[TOPページ]横スクロールが出る(768px～1176px)問題を修正　#28

### DIFF
--- a/assets/scss/component/5.1.grid.scss
+++ b/assets/scss/component/5.1.grid.scss
@@ -6,25 +6,24 @@
   margin: 0;
   @include clearfix;
   @include media_desktop {
-    margin-left:  ceil((30px / -2));
-    margin-right: floor((30px / -2));
+    //margin-left:  ceil((30px / -2));
+    //margin-right: floor((30px / -2));
   }
 }
 
 @mixin makeSmColumn($columns){
   position: relative;
   min-height: 1px;
-  padding-left: 0;
-  padding-right: 0;
+  //padding-left: 0;
+  //padding-right: 0;
 
   @media (min-width: $desktop) {
     float: left;
     width: percentage(($columns/ 12));
   }
   @include media_desktop{
-
-    padding-left:  (30px / 2);
-    padding-right: (30px / 2);
+    //padding-left:  (30px / 2);
+    //padding-right: (30px / 2);
   }
 
 }

--- a/assets/scss/component/7.1.itembanner.scss
+++ b/assets/scss/component/7.1.itembanner.scss
@@ -30,13 +30,20 @@ include /assets/tmpl/elements/7.1.itembanner.pug
 Styleguide 7.1.1
 */
 .ec-displayB{
-  display: inline-block;
   margin-bottom: 24px;
+  display: flex;
+  justify-content: space-between;
   &:hover {
     text-decoration: none;
     img{
       opacity: .8;
     }
+    a {
+      text-decoration: none;
+    }
+  }
+  & &__cell {
+    width: 30%;
   }
   & &__img {
     margin-bottom: 15px;
@@ -145,24 +152,19 @@ Styleguide 7.1.3
 */
 
 .ec-displayD {
-  margin-left: -8px;
-  margin-right: -8px;
+  display:flex;
+  justify-content:space-between;
+
   @include media_desktop(){
-    margin-left: -15px;
-    margin-right: -15px;
+    box-sizing: border-box;
   }
 
   & &__cell{
     width: percentage((1/ 3));
-    float: left;
     margin-bottom: 8px;
-    padding-left: 8px;
-    padding-right: 8px;
     @include media_desktop(){
-      width: percentage((1/ 6));
+      width: percentage((1/ 6.5));
       margin-bottom: 16px;
-      padding-left: 15px;
-      padding-right: 15px;
     }
     &:hover {
       text-decoration: none;

--- a/assets/scss/component/8.1.info.scss
+++ b/assets/scss/component/8.1.info.scss
@@ -30,6 +30,9 @@ Styleguide 8.1.1
   margin-bottom: 16px;
   background: #F8F8F8;
   @include media_desktop {
+    padding-left: 15px;
+  }
+  @include media_desktop {
     margin-bottom: 32px;
   }
   & &__title{
@@ -125,6 +128,7 @@ Styleguide 8.1.3
   font-weight: bold;
   border: 1px solid #ccc;
   @include media_desktop {
+    margin-left: 16px;
     margin-bottom: 0;
   }
   & &__intro {

--- a/assets/scss/project/12.2.eyecatch.scss
+++ b/assets/scss/project/12.2.eyecatch.scss
@@ -18,7 +18,8 @@ Styleguide 12.2
   margin-bottom: 30px;
   text-align: center;
   & &__intro {
-
+    box-sizing: border-box;
+    padding: 0 16px;
   }
   & &__introTitle {
     margin-top: 10px;

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -4,6 +4,7 @@ body {
   font-family: Roboto, "游ゴシック", YuGothic, "Yu Gothic", "ヒラギノ角ゴ ProN W3", "Hiragino Kaku Gothic ProN", Arial, "メイリオ", Meiryo, sans-serif;
   color:#525263;
   transition: z-index 0ms 5.28455ms;
+  background: #f6f6f6;
 }
 @import "component/1.1.heading";
 @import "component/1.2.typo";

--- a/assets/tmpl/elements/7.1.itembanner.pug
+++ b/assets/tmpl/elements/7.1.itembanner.pug
@@ -1,13 +1,13 @@
 mixin ec-displayB
-    .ec-grid3
-        each item in ["","",""]
-            .ec-grid3__cell
-                a(href="/moc/guest/item/").ec-displayB
-                    .ec-displayB__img
-                        img(src="http://demo3.ec-cube.net/template/default/img/top/img03.jpg")
-                    .ec-displayB__catch お気に入りのエスプレッソタイム
-                    .ec-displayB__comment.ec-font-size-1 コーヒータイムを上質な時間にしてくれる、口当たりのよさとデザイン性を兼ね備えたエスプレッソカップを集めました・・・
-                    .ec-displayB__link read more
+        +b.ec-displayB
+            each item in ["","",""]
+                +e.cell
+                    a(href="/moc/guest/item/")
+                        +e.__img
+                            img(src="http://demo3.ec-cube.net/template/default/img/top/img03.jpg")
+                        +e.__catch お気に入りのエスプレッソタイム
+                        +e.__comment.ec-font-size-1 コーヒータイムを上質な時間にしてくれる、口当たりのよさとデザイン性を兼ね備えたエスプレッソカップを集めました・・・
+                        +e.__link read more
 
 mixin ec-displayC
     +b.ec-displayC


### PR DESCRIPTION
[TOPページ]横スクロールが出る(768px～1176px)問題を修正　#28

横スクロールがでてしまう原因はgirdに当てていたmargin-left:  ceil((30px / -2));やmargin-right: floor((30px / -2));でした。
ただし、この記述を消すと別のページに影響が出るのでマージする前に確認・検討してください。
