### PR TITLE
issue #72対応 スタイルガイド側でリンクに下線がつかないように修正

### DIFF
--- a/assets/scss/component/6.3.login.scss
+++ b/assets/scss/component/6.3.login.scss
@@ -1,4 +1,5 @@
 @import "../mixins/media";
+@import "../mixins/projects";
 /*
 ログイン
 
@@ -46,6 +47,10 @@ Styleguide 6.1.1
       }
     }
   }
+  & &__actions {
+    color: #fff;
+    @include reset_link();
+  }
   & &__link {
     margin-top: 5px;
     margin-left: 0;
@@ -57,7 +62,6 @@ Styleguide 6.1.1
     display: none;
     color: $clrRed;
   }
-
 }
 .ec-login.is_active {
   @include media_desktop {
@@ -70,17 +74,18 @@ Styleguide 6.1.1
   }
 }
 
-  /*
-  ゲスト購入
+/*
+ゲスト購入
 
-  http://demo3.ec-cube.net/mypage
+http://demo3.ec-cube.net/mypage
 
-  Markup:
-  include /assets/tmpl/elements/6.3.login.pug
-  +ec-guest
+Markup:
+include /assets/tmpl/elements/6.3.login.pug
++ec-guest
+hoge
 
-  Styleguide 6.1.2
-  */
+Styleguide 6.1.2
+*/
 .ec-guest{
   display: table;
   margin: 0;
@@ -100,6 +105,13 @@ Styleguide 6.1.1
     p {
       margin-bottom: 16px;
     }
+  }
+  & &__actions {
+    display: block;
+    vertical-align: middle;
+    text-align: center;
+    color: #fff;
+    @include reset_link();
   }
   & &__icon{
     font-size: 70px;

--- a/assets/scss/component/7.1.itembanner.scss
+++ b/assets/scss/component/7.1.itembanner.scss
@@ -1,5 +1,5 @@
 @import "../mixins/media";
-
+@import "../mixins/projects";
 /*
 商品掲載
 
@@ -40,6 +40,7 @@ Styleguide 7.1.1
   & &__cell {
     width: 100%;
     margin-bottom: 16px;
+    @include reset_link();
     @include media_desktop {
       width: 31.4466%;
       margin-bottom: 0;
@@ -90,6 +91,7 @@ ex [トップページ　商品紹介部分](http://demo3.ec-cube.net/)
 Markup:
 include /assets/tmpl/elements/7.1.itembanner.pug
 +ec-displayC
+p hoge
 
 Styleguide 7.1.2
 */
@@ -101,6 +103,7 @@ Styleguide 7.1.2
   margin-bottom: 24px;
   & &__cell{
     width: 47%;
+    @include reset_link();
     @include media_desktop(){
       width: 22.8775%;
     }
@@ -172,6 +175,7 @@ Styleguide 7.1.3
   & &__cell{
     width: 30%;
     margin-bottom: 8px;
+    @include reset_link();
     @include media_desktop(){
       width: 14.3083%;
       margin-bottom: 16px;

--- a/assets/scss/project/11.2.header.scss
+++ b/assets/scss/project/11.2.header.scss
@@ -11,7 +11,6 @@ ex [商品詳細ページ　ヘッダー](http://demo3.ec-cube.net/products/deta
 Markup:
 include /assets/tmpl/elements/11.2.header.pug
 +ec-headerRole
-p hoge
 
 Styleguide 11.2
 */

--- a/assets/scss/project/11.3.footer.scss
+++ b/assets/scss/project/11.3.footer.scss
@@ -1,4 +1,5 @@
 @import "../mixins/media";
+@import "../mixins/projects";
 /*
 フッター
 
@@ -9,7 +10,6 @@ ex [商品詳細ページ　フッター](http://demo3.ec-cube.net/products/deta
 Markup:
 include /assets/tmpl/elements/11.3.footer.pug
 +ec-footerRole
-p dhogeddd
 
 Styleguide 11.3
 */
@@ -19,6 +19,7 @@ Styleguide 11.3
   padding-top: 12px;
   padding-bottom: 24px;
   margin-top: 36px;
+
   @include media_desktop(){
     padding-top: 32px;
     margin-top: 80px;
@@ -102,6 +103,7 @@ Styleguide 11.3.2
   }
   & &__logo{
     font-weight: bold;
+    @include reset_link();
     a{
       font-size: 16px;
       color: inherit;

--- a/assets/tmpl/elements/6.3.login.pug
+++ b/assets/tmpl/elements/6.3.login.pug
@@ -60,7 +60,8 @@ mixin ec-guest
     +b.ec-guest
         +e.inner
             p 会員登録をせずに購入手続きをされたい方は、下記よりお進みください。
-            a(href="/moc/guest/cart3").ec-blockBtn--cancel ゲスト購入
+            +e.actions
+                a(href="/moc/guest/cart3").ec-blockBtn--cancel ゲスト購入
 
 
 

--- a/assets/tmpl/elements/7.1.itembanner.pug
+++ b/assets/tmpl/elements/7.1.itembanner.pug
@@ -12,28 +12,28 @@ mixin ec-displayB
 mixin ec-displayC
     +b.ec-displayC
         +e.cell
-            a(href="/moc/guest/item/").ec-displayC
+            a(href="/moc/guest/item/")
                 +e.img
                     img(src="http://demo3.ec-cube.net/upload/save_image/0701104933_5593472d8d179.jpeg")
                 +e.catch 足の透かし模様が美しいミニテーブル
                 +e.title ミニテーブル
                 +e.price ¥ 1,785
         +e.cell
-            a(href="/moc/guest/item/").ec-displayC
+            a(href="/moc/guest/item/")
                 +e.img
                     img(src="http://demo3.ec-cube.net/upload/save_image/0701104933_5593472d8d179.jpeg")
                 +e.catch 足の透かし模様が美しいミニテーブル
                 +e.title ミニテーブル
                 +e.price ¥ 1,785
         +e.cell
-            a(href="/moc/guest/item/").ec-displayC
+            a(href="/moc/guest/item/")
                 +e.img
                     img(src="http://demo3.ec-cube.net/upload/save_image/0701104933_5593472d8d179.jpeg")
                 +e.catch 足の透かし模様が美しいミニテーブル
                 +e.title ミニテーブル
                 +e.price--sp ¥ 1,785
         +e.cell
-            a(href="/moc/guest/item/").ec-displayC
+            a(href="/moc/guest/item/")
                 +e.img
                     img(src="http://demo3.ec-cube.net/upload/save_image/0701104933_5593472d8d179.jpeg")
                 +e.catch 足の透かし模様が美しいミニテーブル


### PR DESCRIPTION
issue #72対応

- ボタン内テキストの下線
- 商品一覧のテキストの下線
- footer店名のテキストの下線 