### PR TITLE
issue #71 新着情報タイトル下のborderのスタイルをデモサイトと同じ状態に。右の余白が下の6分割エリアと同じになるよう調整。

### DIFF
--- a/assets/scss/component/8.1.info.scss
+++ b/assets/scss/component/8.1.info.scss
@@ -30,21 +30,26 @@ Styleguide 8.1.1
   margin-bottom: 16px;
   background: #F8F8F8;
   @include media_desktop {
-    padding-left: 15px;
-    margin-right: 16px;
+    margin-right: 3%;
   }
   @include media_desktop {
     margin-bottom: 32px;
   }
   & &__title{
     font-weight: bold;
-    padding: 16px;
-    font-size: 24px;
+    padding: 8px;
+    font-size: 16px;
+    text-align: center;
+    @include media_desktop {
+      padding: 16px;
+      text-align: left;
+      font-size: 24px;
+    }
   }
   & &__items{
     padding: 0;
     list-style: none;
-    border-top: 1px solid #ccc;
+    border-top: 1px dotted #ccc;
   }
 }
 /*
@@ -129,8 +134,8 @@ Styleguide 8.1.3
   font-weight: bold;
   border: 1px solid #ccc;
   @include media_desktop {
-    margin-left: 16px;
-    margin-bottom: 0;
+    margin-left: 3%;
+    margin-bottom: 16px;
   }
   & &__intro {
     color: #DE5D50;

--- a/assets/tmpl/moc/index.pug
+++ b/assets/tmpl/moc/index.pug
@@ -13,7 +13,7 @@ block content
         +ec-displayC
     .ec-role
         +b.ec-grid3
-           +e.cell2: +ec-news
+           +e.cell3: +ec-news
            +e.cell
             +ec-banner
     .ec-role


### PR DESCRIPTION
issue #71 対応。
- 新着情報タイトル下のborderのスタイルをデモサイトと同じ状態に。
- 右の余白が下の6分割エリアと同じになるよう調整。